### PR TITLE
Added callback to let grunt know when we're done with async operations

### DIFF
--- a/tasks/zopfli.js
+++ b/tasks/zopfli.js
@@ -11,6 +11,8 @@ module.exports = function(grunt) {
       zopfliOptions: {}
     });
 
+    var done = this.async();
+
     grunt.util.async.forEachSeries(this.files, function(filePair, nextPair) {
       grunt.util.async.forEachSeries(filePair.src, function(src, nextFile) {
         if (grunt.file.isDir(src)) {
@@ -28,9 +30,11 @@ module.exports = function(grunt) {
         if (grunt.util._.include(['gzip', 'zlib', 'deflate'], zopfli.options.mode) === false) {
           grunt.fail.warn('Mode ' + zopfli.options.mode + ' is not supported.');
         }
-        console.log(src, filePair.dest);
+        grunt.log.writeln(src, filePair.dest);
         zopfli.compressFile(src, filePair.dest, zopfli.options.mode, zopfli.options.extension, zopfli.options.zopfliOptions, nextFile);
       }, nextPair);
+    }, function(error) {
+      done(!error);
     });
   });
 };


### PR DESCRIPTION
I'm running grunt 0.4.5, with grunt-zopfli-native 0.4.1.
When I ran the task, I saw the output file being created, with size 0.

I guessed this was due to the asynchronous nature of the stream operations, so I modified the code according to [this page](http://gruntjs.com/api/inside-tasks).

As a side note, I also noticed that `grunt.util.async` is now deprecated, though still working at the moment. You may want to look into this at a later time.
