### PR TITLE
Allow files to be compressed in parallel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ Forces an extension to your files. Defaults depends on the mode chosen.
  zopfli({ format: 'zlib' })
  ```
 
+#### limit `Number`
+
+Limit on the number of files compressed in parallel. Defaults to the number of CPUs on the host (as per the `os` module).
+
+```javascript
+ zopfli({ limit: 1 })
+ ```
+
 #### zopfliOptions `Object`
 
 Options object to pass through to node-zopfli. See [node-zopfli documentation](https://github.com/pierreinglebert/node-zopfli#options) for more information.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Forces an extension to your files. Defaults depends on the mode chosen.
 
 Limit on the number of files compressed in parallel. Defaults to the number of CPUs on the host (as per the `os` module).
 
+_Setting this limit greater than UV_THREADPOOL_SIZE (defaults to 4) won't really work as desired. Increasing UV_THREADPOOL_SIZE is a good idea if needed. (e.g. `UV_THREADPOOL_SIZE=10 grunt zopfli`)_
+
 ```javascript
  zopfli({ limit: 1 })
  ```

--- a/tasks/zopfli.js
+++ b/tasks/zopfli.js
@@ -37,7 +37,7 @@ module.exports = function(grunt) {
         }
         promises.push(function(cb) {
           zopfli.compressFile(src, filePair.dest, zopfli.options.mode, zopfli.options.extension, zopfli.options.zopfliOptions, cb);
-        })
+        });
       });
     });
     async.parallelLimit(promises, zopfli.options.limit, function(error) {

--- a/tasks/zopfli.js
+++ b/tasks/zopfli.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var async = require('async');
+var async = require('async'),
+  os = require('os');
 
 module.exports = function(grunt) {
 
@@ -10,15 +11,17 @@ module.exports = function(grunt) {
     zopfli.options = this.options({
       mode: null,
       extension: null,
+      limit: os.cpus().length,
       zopfliOptions: {}
     });
 
-    var done = this.async();
+    var done = this.async(),
+      promises = [];
 
-    async.forEachSeries(this.files, function(filePair, nextPair) {
-      async.forEachSeries(filePair.src, function(src, nextFile) {
+    this.files.forEach(function(filePair) {
+      filePair.src.forEach(function(src) {
         if (grunt.file.isDir(src)) {
-          return nextFile();
+          return;
         }
 
         if(zopfli.options.mode === null) {
@@ -32,9 +35,12 @@ module.exports = function(grunt) {
         if (grunt.util._.include(['gzip', 'zlib', 'deflate'], zopfli.options.mode) === false) {
           grunt.fail.warn('Mode ' + zopfli.options.mode + ' is not supported.');
         }
-        zopfli.compressFile(src, filePair.dest, zopfli.options.mode, zopfli.options.extension, zopfli.options.zopfliOptions, nextFile);
-      }, nextPair);
-    }, function(error) {
+        promises.push(function(cb) {
+          zopfli.compressFile(src, filePair.dest, zopfli.options.mode, zopfli.options.extension, zopfli.options.zopfliOptions, cb);
+        })
+      });
+    });
+    async.parallelLimit(promises, zopfli.options.limit, function(error) {
       done(!error);
     });
   });


### PR DESCRIPTION
By using the `async.parallelLimit` function, it's possible to compress multiple files in parallel, rather than executing serially.