### PR TITLE
"grunt.util._" is deprecated- add lodash dependency & use lodash directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "dependencies": {
     "async": "^1.5.2",
-    "lodash": "^4.7.0",
     "node-zopfli": "^1.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "async": "^1.5.2",
+    "lodash": "^4.7.0",
     "node-zopfli": "^1.1.0"
   },
   "devDependencies": {

--- a/tasks/zopfli.js
+++ b/tasks/zopfli.js
@@ -5,6 +5,7 @@ var os = require('os');
 
 module.exports = function(grunt) {
 
+  var _ = require('lodash');
   var zopfli = require('./lib/zopfli')(grunt);
 
   grunt.registerMultiTask('zopfli', 'Compress files.', function() {
@@ -32,7 +33,7 @@ module.exports = function(grunt) {
           zopfli.options.extension = zopfli.detectExtension(zopfli.options.mode);
         }
 
-        if (grunt.util._.include(['gzip', 'zlib', 'deflate'], zopfli.options.mode) === false) {
+        if (_.includes(['gzip', 'zlib', 'deflate'], zopfli.options.mode) === false) {
           grunt.fail.warn('Mode ' + zopfli.options.mode + ' is not supported.');
         }
         promises.push(function(cb) {

--- a/tasks/zopfli.js
+++ b/tasks/zopfli.js
@@ -32,7 +32,7 @@ module.exports = function(grunt) {
           zopfli.options.extension = zopfli.detectExtension(zopfli.options.mode);
         }
 
-        if (grunt.util._.include(['gzip', 'zlib', 'deflate'], zopfli.options.mode) === false) {
+        if (['gzip', 'zlib', 'deflate'].indexOf(zopfli.options.mode) === -1) {
           grunt.fail.warn('Mode ' + zopfli.options.mode + ' is not supported.');
         }
         promises.push(function(cb) {

--- a/tasks/zopfli.js
+++ b/tasks/zopfli.js
@@ -5,6 +5,7 @@ var os = require('os');
 
 module.exports = function(grunt) {
 
+  var _ = require('lodash');
   var zopfli = require('./lib/zopfli')(grunt);
 
   grunt.registerMultiTask('zopfli', 'Compress files.', function() {
@@ -32,7 +33,7 @@ module.exports = function(grunt) {
           zopfli.options.extension = zopfli.detectExtension(zopfli.options.mode);
         }
 
-        if (['gzip', 'zlib', 'deflate'].indexOf(zopfli.options.mode) === -1) {
+        if (_.includes(['gzip', 'zlib', 'deflate'], zopfli.options.mode) === false) {
           grunt.fail.warn('Mode ' + zopfli.options.mode + ' is not supported.');
         }
         promises.push(function(cb) {

--- a/tasks/zopfli.js
+++ b/tasks/zopfli.js
@@ -5,7 +5,6 @@ var os = require('os');
 
 module.exports = function(grunt) {
 
-  var _ = require('lodash');
   var zopfli = require('./lib/zopfli')(grunt);
 
   grunt.registerMultiTask('zopfli', 'Compress files.', function() {
@@ -33,7 +32,7 @@ module.exports = function(grunt) {
           zopfli.options.extension = zopfli.detectExtension(zopfli.options.mode);
         }
 
-        if (_.includes(['gzip', 'zlib', 'deflate'], zopfli.options.mode) === false) {
+        if (['gzip', 'zlib', 'deflate'].indexOf(zopfli.options.mode) === -1) {
           grunt.fail.warn('Mode ' + zopfli.options.mode + ' is not supported.');
         }
         promises.push(function(cb) {

--- a/tasks/zopfli.js
+++ b/tasks/zopfli.js
@@ -5,7 +5,6 @@ var os = require('os');
 
 module.exports = function(grunt) {
 
-  var _ = require('lodash');
   var zopfli = require('./lib/zopfli')(grunt);
 
   grunt.registerMultiTask('zopfli', 'Compress files.', function() {
@@ -33,7 +32,7 @@ module.exports = function(grunt) {
           zopfli.options.extension = zopfli.detectExtension(zopfli.options.mode);
         }
 
-        if (_.includes(['gzip', 'zlib', 'deflate'], zopfli.options.mode) === false) {
+        if (grunt.util._.include(['gzip', 'zlib', 'deflate'], zopfli.options.mode) === false) {
           grunt.fail.warn('Mode ' + zopfli.options.mode + ' is not supported.');
         }
         promises.push(function(cb) {


### PR DESCRIPTION
This should close #12. Note that I didn't do any testing with `node` 0.10, 0.12, or 4.x.
Changes were made based on `grunt-contrib-compress` 1.20 resolution of a similar issue; see the commit to that repo here: [Use lodash directly. Fixes GH-177. ](https://github.com/gruntjs/grunt-contrib-compress/commit/2edf867cda5e96fadeee0cd93acceb0b37b3a42c)
