### PR TITLE
improve grunt 1.x.x compatibility by using indexOf() instead of deprecated grunt.util._

### DIFF
--- a/tasks/zopfli.js
+++ b/tasks/zopfli.js
@@ -32,7 +32,7 @@ module.exports = function(grunt) {
           zopfli.options.extension = zopfli.detectExtension(zopfli.options.mode);
         }
 
-        if (grunt.util._.include(['gzip', 'zlib', 'deflate'], zopfli.options.mode) === false) {
+        if (['gzip', 'zlib', 'deflate'].indexOf(zopfli.options.mode) === -1) {
           grunt.fail.warn('Mode ' + zopfli.options.mode + ' is not supported.');
         }
         promises.push(function(cb) {


### PR DESCRIPTION
Starting with grunt 1.0.0 lodash is not implicitly included. Per recommendation this avoids add lodash as a dependency, yet still validates the zopfoli 