### PR TITLE
Update readme information and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ zopfli: {
 }
 ```
 
-#### Gzip files and overwrite originals
+#### Gzip files and preserve filenames
 
 ```js
 zopfli: {
@@ -102,7 +102,7 @@ zopfli: {
       expand: true,
       cwd: 'build/',
       src: ['*.{png,jpg,js}'],
-      dest: 'build/'
+      dest: 'build/compressed/'
     }],
     options: {
       extension: ''

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Task targets, files and options may be specified according to the grunt [Configu
 Choose an output format, you can choose between `gzip`, `zlib` or `deflate`. Defaults to gzip.
 
 ```js
-zopfli({ format: 'zlib' })
+zopfli({ mode: 'zlib' })
  ```
 
 #### extension `String`
@@ -33,8 +33,10 @@ zopfli({ format: 'zlib' })
 Forces an extension to your files. Defaults depends on the mode chosen.
 
 ```js
-zopfli({ format: 'zlib' })
+zopfli({ extension: '.gzip' })
  ```
+ 
+Providing an empty string will disable adding an extension (eg. preventing '.gz' being added when gzip mode is used).
 
 #### limit `Number`
 
@@ -87,6 +89,24 @@ zopfli: {
     cwd: 'assets/',
     src: ['**/*'],
     dest: 'public/'
+  }
+}
+```
+
+#### Gzip files and overwrite originals
+
+```js
+zopfli: {
+  main: {
+    files: [{
+      expand: true,
+      cwd: 'build/',
+      src: ['*.{png,jpg,js}'],
+      dest: 'build/'
+    }],
+    options: {
+      extension: ''
+    }
   }
 }
 ```


### PR DESCRIPTION
Added a new gzip+extension example and correct options in mode/extension documentation.

A couple of the documentation examples (mode/extension) had `format` instead of the correct configuration key. I added what I feel to be a useful example showing how to gzip and overwrite the original files in a directory with gzipped copies - this is effective for deployment directories that are going to destinations like Amazon S3 (for example), where Content-Type headers are added but the filenames must be exact (no .gz).