### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,18 +20,18 @@
     "test": "grunt"
   },
   "dependencies": {
-    "async": "^1.5.2",
-    "node-zopfli": "^1.1.0"
+    "async": "^3.1.0",
+    "node-zopfli": "^2.0.3"
   },
   "devDependencies": {
-    "grunt": "^0.4.0",
-    "grunt-cli": "^0.1.13",
-    "grunt-contrib-clean": "^1.0.0",
-    "grunt-contrib-jshint": "^1.0.0",
-    "grunt-contrib-nodeunit": "^1.0.0"
+    "grunt": ">=1.0.4",
+    "grunt-cli": "^1.3.2",
+    "grunt-contrib-clean": "^2.0.0",
+    "grunt-contrib-jshint": "^2.1.0",
+    "grunt-contrib-nodeunit": "^2.0.0"
   },
   "peerDependencies": {
-    "grunt": ">=0.4.0"
+    "grunt": ">=1.0.4"
   },
   "keywords": [
     "grunt",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-zopfli-native",
   "description": "Compress files and folders using zopfli algorithm.",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "homepage": "https://github.com/pierreinglebert/grunt-zopfli-native",
   "author": "Pierre Inglebert (https://github.com/pierreinglebert)",
   "repository": {


### PR DESCRIPTION
This updates dependencies and bumps version to 1.1.0.  I am unable to install node-zopfli 1.x under Node 12.  Tests pass and it works for me, but there could be important things that I missed in the jump from grunt 0.4 to 1.0.